### PR TITLE
Completed runtime based on BinaryReader and .NET naming standards

### DIFF
--- a/KaitaiStream.cs
+++ b/KaitaiStream.cs
@@ -33,7 +33,7 @@ namespace Kaitai
         {
 
         }
-        
+
         #endregion
 
         /// <summary>
@@ -355,6 +355,16 @@ namespace Kaitai
                     throw new NotImplementedException($"Unable to rotate a group of {groupSize} bytes yet");
             }
             return r;
+        }
+
+        public byte[] ProcessXorInt(byte[] value, int xorValue)
+        {
+            var result = new byte[value.Length];
+            for (int i = 0; i < value.Length; i++)
+            {
+                result[i] = (byte) (value[i] ^ xorValue);
+            }
+            return result;
         }
     }
 }

--- a/KaitaiStream.cs
+++ b/KaitaiStream.cs
@@ -199,7 +199,7 @@ namespace Kaitai
         /// <returns></returns>
         public ulong ReadU8be()
         {
-            byte[] buffer = readBytes(8);
+            byte[] buffer = ReadBytes(8);
             return (ulong) (
                 ( buffer[0] << 56) +  // high byte
                 ( buffer[1] << 48) +
@@ -217,7 +217,7 @@ namespace Kaitai
         /// <returns></returns>
         public long ReadS8be()
         {
-            byte[] buffer = readBytes(8);
+            byte[] buffer = ReadBytes(8);
             return (Int64) (
                 ( buffer[0] << 56) +  // high byte
                 ( buffer[1] << 48) +
@@ -259,7 +259,7 @@ namespace Kaitai
         /// </summary>
         /// <param name="encoding">The string encoding to use</param>
         /// <returns></returns>
-        public string ReadStringEos(string encoding)
+        public string ReadStrEos(string encoding)
         {
             return System.Text.Encoding.GetEncoding(encoding).GetString(ReadBytesFull());
         }
@@ -270,7 +270,7 @@ namespace Kaitai
         /// <param name="length">The number of bytes to read</param>
         /// <param name="encoding">The string encoding to use</param>
         /// <returns></returns>
-        public string ReadStringByteLimit(long length, string encoding)
+        public string ReadStrByteLimit(long length, string encoding)
         {
             return System.Text.Encoding.GetEncoding(encoding).GetString(ReadBytes(length));
         }
@@ -284,7 +284,7 @@ namespace Kaitai
         /// <param name="consumeTerminator">True to consume the terminator byte before returning</param>
         /// <param name="eosError">True to throw an error when the EOS was reached before the terminator</param>
         /// <returns></returns>
-        public string ReadStringTerminated(string encoding, byte terminator, bool includeTerminator, bool consumeTerminator, bool eosError)
+        public string ReadStrz(string encoding, byte terminator, bool includeTerminator, bool consumeTerminator, bool eosError)
         {
             var bytes = new System.Collections.Generic.List<byte>();
             while (true)

--- a/KaitaiStruct.cs
+++ b/KaitaiStruct.cs
@@ -2,15 +2,18 @@ using System;
 
 namespace Kaitai
 {
-    public class KaitaiStruct
+    public abstract class KaitaiStruct
     {
-        protected KaitaiStream m_io;
+        protected KaitaiStream _stream;
 
-        public KaitaiStruct(KaitaiStream _io)
+        public KaitaiStream GetKaitaiStream()
         {
-            m_io = _io;
+            return _stream;
         }
 
-        public KaitaiStream _io() { return m_io; }
+        public KaitaiStruct(KaitaiStream stream)
+        {
+            _stream = stream;
+        }
     }
 }

--- a/KaitaiStruct.cs
+++ b/KaitaiStruct.cs
@@ -4,16 +4,19 @@ namespace Kaitai
 {
     public abstract class KaitaiStruct
     {
-        protected KaitaiStream _stream;
+        protected KaitaiStream m_io;
 
-        public KaitaiStream GetKaitaiStream()
+        public KaitaiStream M_Io
         {
-            return _stream;
+            get
+            {
+                return m_io;
+            }
         }
 
-        public KaitaiStruct(KaitaiStream stream)
+        public KaitaiStruct(KaitaiStream io)
         {
-            _stream = stream;
+            m_io = io;
         }
     }
 }


### PR DESCRIPTION
This is the companion PR for kaitai-io/kaitai_struct_compiler#2. This is based on .NET's BinaryReader class which has native implementations for many of the little-endian methods in the Kaitai API. The rest are copied from the Java implementation. BinaryReader throws `EndOfStreamException` when you attempt to read past the end of the stream, so a lot of the exception handling from the Java implementation has been removed in favour of passing through the raw .NET exception.

Testing so far is just compile-time - no runtime testing performed. Once the C# compiler is finalised, I'd be happy to port the suite of unit tests to .NET.
