### PR TITLE
Move down to C# 2.0 features

### DIFF
--- a/KaitaiStream.cs
+++ b/KaitaiStream.cs
@@ -429,6 +429,7 @@ namespace Kaitai
                     if (bytes[i] != expected[i])
                     {
                         error = true;
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
Sanity check please @xavrr @GreyCat 
Fixes kaitai-io/kaitai_struct#74

Note: `SequenceEqual` isn't available on C# 2.0 so I've replaced it with a basic array compare.