### PR TITLE
Add NuGet package configuration details for KaitaiStruct.Runtime.CSharp.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -251,3 +251,4 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+/nuget.exe

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -4,20 +4,16 @@ using System.Runtime.CompilerServices;
 // Information about this assembly is defined by the following attributes.
 // Change them to the values specific to your project.
 
-[assembly: AssemblyTitle("kaitai_struct_runtime_csharp")]
-[assembly: AssemblyDescription("")]
+// NOTE: These attributes are used in the kaitai_struct_runtime_csharp.nuspec NuGet package config file.
+[assembly: AssemblyTitle("KaitaiStruct.Runtime.CSharp")]
+[assembly: AssemblyDescription("This library implements Kaitai Struct API for C#.")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("")]
-[assembly: AssemblyCopyright("Kaitai Project")]
+[assembly: AssemblyCompany("Kaitai Project")]
+[assembly: AssemblyProduct("Kaitai Struct Runtime")]
+[assembly: AssemblyCopyright("Copyright © Kaitai Project 2016-2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("0.7.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.CompilerServices;
 // Change them to the values specific to your project.
 
 // NOTE: These attributes are used in the kaitai_struct_runtime_csharp.nuspec NuGet package config file.
-[assembly: AssemblyTitle("KaitaiStruct.Runtime.CSharp")]
+[assembly: AssemblyTitle("Kaitai.Struct.Runtime")]
 [assembly: AssemblyDescription("This library implements Kaitai Struct API for C#.")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Kaitai Project")]

--- a/kaitai_struct_runtime_csharp.csproj
+++ b/kaitai_struct_runtime_csharp.csproj
@@ -5,8 +5,8 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{8339A750-C407-4CE8-8E31-51CB2EFD3A4B}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <RootNamespace>KaitaiStruct</RootNamespace>
-    <AssemblyName>KaitaiStruct.Runtime.CSharp</AssemblyName>
+    <RootNamespace>Kaitai</RootNamespace>
+    <AssemblyName>Kaitai.Struct.Runtime</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -26,6 +26,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
+    <DocumentationFile>bin\Release\Kaitai.Struct.Runtime.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/kaitai_struct_runtime_csharp.csproj
+++ b/kaitai_struct_runtime_csharp.csproj
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{8339A750-C407-4CE8-8E31-51CB2EFD3A4B}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <RootNamespace>kaitai_struct_runtime_csharp</RootNamespace>
-    <AssemblyName>kaitai_struct_runtime_csharp</AssemblyName>
+    <RootNamespace>KaitaiStruct</RootNamespace>
+    <AssemblyName>KaitaiStruct.Runtime.CSharp</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -34,6 +34,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="KaitaiStream.cs" />
     <Compile Include="KaitaiStruct.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="kaitai_struct_runtime_csharp.nuspec" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/kaitai_struct_runtime_csharp.nuspec
+++ b/kaitai_struct_runtime_csharp.nuspec
@@ -12,7 +12,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>$description$</description>
     <releaseNotes>
-      Changed default namespace to Katai.
+      Changed default namespace to Kaitai.
       Changed assembly name to Kaitai.Struct.Runtime.
     </releaseNotes>
     <copyright>$copyright$</copyright>

--- a/kaitai_struct_runtime_csharp.nuspec
+++ b/kaitai_struct_runtime_csharp.nuspec
@@ -11,7 +11,10 @@
     <iconUrl>https://avatars2.githubusercontent.com/u/17322584?s=280&amp;v=4</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>$description$</description>
-    <releaseNotes>Initial NuGet release.</releaseNotes>
+    <releaseNotes>
+      Changed default namespace to Katai.
+      Changed assembly name to Kaitai.Struct.Runtime.
+    </releaseNotes>
     <copyright>$copyright$</copyright>
     <tags>Kaitai Struct File-Format Binary Protocols</tags>
   </metadata>

--- a/kaitai_struct_runtime_csharp.nuspec
+++ b/kaitai_struct_runtime_csharp.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>$title$</title>
+    <authors>$author$</authors>
+    <owners>$author$</owners>
+    <licenseUrl>https://github.com/kaitai-io/kaitai_struct_csharp_runtime/blob/master/LICENSE</licenseUrl>
+    <projectUrl>http://kaitai.io/</projectUrl>
+    <iconUrl>https://avatars2.githubusercontent.com/u/17322584?s=280&amp;v=4</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>$description$</description>
+    <releaseNotes>Initial NuGet release.</releaseNotes>
+    <copyright>$copyright$</copyright>
+    <tags>Kaitai Struct File-Format Binary Protocols</tags>
+  </metadata>
+</package>


### PR DESCRIPTION
Changes needed to create a NuGet package from the project for .NET 4.5+.
Package can be [downloaded from here](https://www.nuget.org/packages/KaitaiStruct.Runtime.CSharp/).