### PR TITLE
Kaitai b32 result is inconsistent for some payload because of overflo…

### DIFF
--- a/KaitaiStream.cs
+++ b/KaitaiStream.cs
@@ -333,7 +333,7 @@ namespace Kaitai
                 byte[] buf = ReadBytes(bytesNeeded);
                 for (int i = 0; i < buf.Length; i++)
                 {
-                    ulong v = (ulong)(buf[i] << BitsLeft);
+                    ulong v = (ulong)((ulong)buf[i] << BitsLeft);
                     Bits |= v;
                     BitsLeft += 8;
                 }


### PR DESCRIPTION
To avoid the overflow we have to cast it to ulong